### PR TITLE
Fix duplicate autocmds on config reload

### DIFF
--- a/lua/aggregators/plugins.lua
+++ b/lua/aggregators/plugins.lua
@@ -11,13 +11,12 @@ local v = vim.v
 local function bootstrap_lazy()
 	local lazypath = fn.stdpath("data") .. "/lazy/lazy.nvim"
 	if not uv.fs_stat(lazypath) then
-		local lazyrepo = "https://github.com/folke/lazy.nvim.git"
 		local out = fn.system({
 			"git",
 			"clone",
 			"--filter=blob:none",
 			"--branch=stable",
-			lazyrepo,
+			"https://github.com/folke/lazy.nvim.git",
 			lazypath,
 		})
 

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -1,6 +1,10 @@
 -- Setup localized vim variables
 local api = vim.api
 local highlight = vim.highlight
+local opt_local = vim.opt_local
+
+-- Import required modules
+local map = require("utils.keymap").map
 
 local M = {}
 
@@ -10,6 +14,21 @@ function M.setup()
 		group = api.nvim_create_augroup("highlight_yank", { clear = true }),
 		callback = function()
 			highlight.on_yank({ higroup = "Visual", timeout = 200 })
+		end,
+	})
+
+	-- Close lazy window on escape
+	api.nvim_create_autocmd("FileType", {
+		pattern = "lazy",
+		callback = function(event)
+			map("<esc>", "<cmd>close<cr>", "Close Lazy", { buffer = event.buf })
+		end,
+	})
+
+	-- Disable comment auto-wrapping
+	api.nvim_create_autocmd("BufEnter", {
+		callback = function()
+			opt_local.formatoptions:remove({ "c", "r", "o" })
 		end,
 	})
 end

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -19,6 +19,7 @@ function M.setup()
 
 	-- Close lazy window on escape
 	api.nvim_create_autocmd("FileType", {
+		group = api.nvim_create_augroup("lazy_filetype", { clear = true }),
 		pattern = "lazy",
 		callback = function(event)
 			map("<esc>", "<cmd>close<cr>", "Close Lazy", { buffer = event.buf })
@@ -27,6 +28,7 @@ function M.setup()
 
 	-- Disable comment auto-wrapping
 	api.nvim_create_autocmd("BufEnter", {
+		group = api.nvim_create_augroup("disable_comment_autowrap", { clear = true }),
 		callback = function()
 			opt_local.formatoptions:remove({ "c", "r", "o" })
 		end,

--- a/lua/vim_settings.lua
+++ b/lua/vim_settings.lua
@@ -17,6 +17,7 @@ function M.apply()
 	opt.incsearch = true -- Show search results as you type
 	opt.ignorecase = true -- Ignore case when searching
 	opt.smartcase = true -- Override ignorecase when pattern contains uppercase characters
+	opt.hlsearch = false -- Prevent persistent search highlighting
 
 	-- Layout
 	opt.ruler = false -- Hide the ruler
@@ -49,13 +50,24 @@ function M.apply()
 	opt.undofile = true -- Enable persistent undo
 	opt.swapfile = false -- Do not create a swapfile
 
+	-- Whitespace
+	opt.list = true
+	opt.listchars = {
+		tab = "→ ",
+		space = "·",
+		trail = "•",
+		nbsp = "␣",
+		extends = "›",
+		precedes = "‹",
+	}
+	opt.fillchars = {
+		eob = " ",
+	}
+
 	-- Spell check
 	opt.spell = true -- Enable spell checking
 	opt.spelllang = "en_us" -- Set the spell language to English
 	opt.spelloptions = "camel" -- Treat camelCase as separate words for spell checking
-
-	-- Formatting
-	cmd("autocmd BufEnter * set formatoptions-=cro") -- Disable comment auto-wrapping
 end
 
 return M


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only changes affecting Neovim UI/behavior (whitespace rendering, search highlighting, and a couple of autocmds) with no data or security impact.
> 
> **Overview**
> Enables visible whitespace by turning on `opt.list` and configuring `listchars`/`fillchars`, and disables persistent search highlighting via `opt.hlsearch = false`.
> 
> Moves “disable comment auto-wrapping” from a global `autocmd` string to a proper Lua `BufEnter` autocmd using `opt_local.formatoptions`, and adds a `FileType=lazy` mapping so `<esc>` closes the Lazy.nvim window. Also removes an unnecessary local variable when cloning `lazy.nvim`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5367318357dd243d5b6bcde40a046761c8cd2813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible whitespace indicators for tabs, spaces, trailing chars, and special symbols.

* **Improvements**
  * Disabled persistent search highlighting to reduce visual distractions.
  * Added a quick keyboard shortcut to close specific buffers with Esc.
  * Adjusted comment auto-formatting: behavior refined and applied more selectively across buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->